### PR TITLE
Remove Clipboard Indicator extension incompatible with GNOME v50

### DIFF
--- a/recipes/recipe.yml
+++ b/recipes/recipe.yml
@@ -302,6 +302,7 @@ modules:
       - Blur my Shell
       - Bluetooth Battery Meter
       - Caffeine
+      - 5278  # Pano - Clipboard Manager
 
   - type: systemd
     system:

--- a/recipes/recipe.yml
+++ b/recipes/recipe.yml
@@ -302,7 +302,6 @@ modules:
       - Blur my Shell
       - Bluetooth Battery Meter
       - Caffeine
-      - 779  # Clipboard Indicator
 
   - type: systemd
     system:

--- a/recipes/recipe.yml
+++ b/recipes/recipe.yml
@@ -302,7 +302,7 @@ modules:
       - Blur my Shell
       - Bluetooth Battery Meter
       - Caffeine
-      - 5278  # Pano - Clipboard Manager
+      - 8834  # Copyous - Clipboard Manager
 
   - type: systemd
     system:


### PR DESCRIPTION
Extension ID 779 (Clipboard Indicator) does not support GNOME 50,
causing the gnome-extensions module to fail at build time.

https://claude.ai/code/session_01TNZmFCPNjAXQJWkM8okbwR