### PR TITLE
docs: improve ujust command descriptions and fix shell syntax errors

### DIFF
--- a/config/files/usr/share/ublue-os/just/60-custom.just
+++ b/config/files/usr/share/ublue-os/just/60-custom.just
@@ -1,7 +1,7 @@
 # vim: set ft=make :
 # Custom commands for your Bluefin+Bazzite hybrid
 
-# Your custom AGS dependencies installation
+# Install AGS (Aylur's GTK Shell) runtime dependencies: bun, sass, matugen, and Python color/theme utilities
 ags-deps:
     sudo npm -g install bun
     sudo npm -g install sass

--- a/config/files/usr/share/ublue-os/just/bluefin-system.just
+++ b/config/files/usr/share/ublue-os/just/bluefin-system.just
@@ -268,8 +268,8 @@ configure-auto-power-profile ACTION="help":
     OPTION={{ ACTION }}
     if [ "$OPTION" == "help" ]; then
       echo "Usage: ujust configure-auto-power-profile <option>"
-      echo "  Use 'enable' to allow automatic power profile switching based on power state
-      echo "  Use 'disable' to prevent automatic power profile switching based on power state
+      echo "  Use 'enable' to allow automatic power profile switching based on power state"
+      echo "  Use 'disable' to prevent automatic power profile switching based on power state"
       exit 0
     elif [[ "${OPTION,,}" =~ enable ]]; then
       gnome-extensions enable auto-power-profile@dmy3k.github.io
@@ -295,8 +295,9 @@ install-system-flatpaks:
 #configure-grub:
 #    /usr/libexec/configure-grub.sh
 
+# Update system image via bootc, then update flatpaks and brew packages (incompatible with locally layered packages)
 update-ng:
-    echo "Note: This command doesn't work if you have locally layered packages" 
+    echo "Note: This command doesn't work if you have locally layered packages"
     sudo bootc upgrade
     flatpak update -y
     brew upgrade


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Replace the placeholder description for `ags-deps` with a clear summary of what dependencies are installed (bun, sass, matugen, Python color/theme utilities)
- Add a missing description comment for the `update-ng` command so it appears properly in `ujust --choose`
- Fix unclosed string literals in `configure-auto-power-profile` help text that would cause shell parse errors

## Test plan

- [ ] Run `ujust --choose` and verify `ags-deps` and `update-ng` show meaningful descriptions
- [ ] Run `ujust configure-auto-power-profile help` and verify the help text prints without errors

https://claude.ai/code/session_01EWUuXQUb5FTVX36mnUJSe4
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EWUuXQUb5FTVX36mnUJSe4)_