### PR TITLE
Add claude-cowork-linux to the image

### DIFF
--- a/config/files/usr/bin/claude-cowork
+++ b/config/files/usr/bin/claude-cowork
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+#
+# claude-cowork launcher for immutable (ostree) systems.
+#
+# The image ships the claude-cowork-linux source read-only under /usr/share.
+# Its upstream install/launch flow writes into the working tree and the user's
+# home and downloads Anthropic's proprietary Claude Desktop at runtime, so we
+# mirror the source into a writable per-user copy and drive it from there
+# (the same strategy the upstream Nix flake uses).
+#
+# Usage:
+#   claude-cowork                first run downloads & patches Claude Desktop,
+#                                subsequent runs launch it
+#   claude-cowork --force        skip the download confirmation prompt
+#   claude-cowork --doctor       run upstream preflight diagnostics
+#   claude-cowork --reinstall    wipe the per-user copy and re-run install
+#
+set -euo pipefail
+
+SRC=/usr/share/claude-cowork-linux
+DEST="${XDG_DATA_HOME:-$HOME/.local/share}/claude-cowork-linux"
+
+if [[ ! -d "$SRC" ]]; then
+  echo "claude-cowork: $SRC not found; this image was not built with claude-cowork-linux." >&2
+  exit 1
+fi
+
+if [[ "${1:-}" == "--reinstall" ]]; then
+  shift
+  rm -rf "$DEST"
+fi
+
+# Mirror the read-only source into a writable per-user copy. Preserve the
+# user's extracted app and patches (linux-app-extracted/) across image updates.
+mkdir -p "$DEST"
+if command -v rsync >/dev/null 2>&1; then
+  rsync -a --exclude 'linux-app-extracted' "$SRC"/ "$DEST"/
+else
+  cp -rn "$SRC"/. "$DEST"/ 2>/dev/null || cp -r "$SRC"/. "$DEST"/
+fi
+
+cd "$DEST"
+
+# First run: extract & patch Claude Desktop into the user's home. install.sh
+# prompts before downloading the proprietary DMG; pass --force to skip it.
+if [[ ! -d "$DEST/linux-app-extracted" ]]; then
+  echo "claude-cowork: first run — installing Claude Desktop into your home."
+  echo "claude-cowork: this downloads Anthropic's proprietary Claude Desktop DMG."
+  exec ./install.sh "$@"
+fi
+
+# Already installed: launch (launch.sh repacks the asar if stubs changed).
+exec ./launch.sh "$@"

--- a/config/scripts/getclaude-cowork.sh
+++ b/config/scripts/getclaude-cowork.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+# Tell this script to exit if there are any errors.
+# You should have this in every custom script, to ensure that your completed
+# builds actually ran successfully without any errors!
+set -oue pipefail
+
+# Stage claude-cowork-linux into the image.
+#
+# claude-cowork-linux runs Claude Desktop's Cowork mode natively on Linux.
+# Its install/launch flow is per-user and runtime-driven (it downloads
+# Anthropic's proprietary Claude Desktop DMG into the user's home), so we do
+# NOT bake the app itself into the image. Instead we bake the dependencies and
+# the upstream source, and ship a launcher (/usr/bin/claude-cowork) that
+# bootstraps the install into the user's writable home on first run.
+
+echo 'Staging claude-cowork-linux...'
+
+# Node global tools the upstream launcher needs: electron + @electron/asar.
+# During the BlueBuild build /usr is writable, so `npm -g` lands in the image
+# (binaries symlinked into /usr/bin), keeping them on PATH at runtime where
+# /usr is read-only.
+npm install -g @electron/asar electron
+
+# Clone the upstream source read-only into the image. The launcher mirrors
+# this into ~/.local/share at runtime (same strategy as the upstream Nix flake).
+rm -rf /usr/share/claude-cowork-linux
+git clone --depth=1 https://github.com/johnzfitch/claude-cowork-linux.git /usr/share/claude-cowork-linux
+# Drop the upstream .git to keep the image lean.
+rm -rf /usr/share/claude-cowork-linux/.git
+
+echo 'claude-cowork-linux staged at /usr/share/claude-cowork-linux'

--- a/recipes/recipe.yml
+++ b/recipes/recipe.yml
@@ -190,6 +190,13 @@ modules:
         - hunspell-en-US
         - python3-pip
         - cargo
+
+        # claude-cowork-linux dependencies
+        - nodejs
+        - npm
+        - p7zip
+        - p7zip-plugins
+        - bubblewrap
         
         # AGS (might be problematic)
         - aylurs-gtk-shell
@@ -264,6 +271,7 @@ modules:
     scripts:
       - getsimplex.sh
       - git.sh
+      - getclaude-cowork.sh
       - post-install.sh
 
   - type: fonts


### PR DESCRIPTION
## Summary

Integrates [claude-cowork-linux](https://github.com/johnzfitch/claude-cowork-linux) (run Claude Desktop's Cowork mode natively on Linux, no macOS/VM) into the BlueBuild image.

Because the upstream flow is **per-user and runtime-driven** — `install.sh` downloads Anthropic's proprietary Claude Desktop DMG into the user's `~/.config/Claude` — the app itself is *not* baked into the read-only image. Instead this bakes the dependencies + upstream source and ships a launcher that bootstraps the install into the user's writable home on first run (the same strategy as upstream's Nix flake).

## Changes

- **`recipes/recipe.yml`**
  - Add dnf deps: `nodejs`, `npm`, `p7zip`, `p7zip-plugins`, `bubblewrap` (`skip-unavailable: true` already set).
  - Wire `getclaude-cowork.sh` into the `script` module.
- **`config/scripts/getclaude-cowork.sh`** (build-time) — `npm install -g @electron/asar electron` (lands in `/usr` during build) and clones the upstream source to `/usr/share/claude-cowork-linux` (read-only, `.git` stripped).
- **`config/files/usr/bin/claude-cowork`** — launcher that mirrors `/usr/share/claude-cowork-linux` → `~/.local/share/claude-cowork-linux` (writable), runs `install.sh` on first run, `launch.sh` thereafter. Supports `--force`, `--doctor`, `--reinstall`.

## Usage after rebuild

```
claude-cowork            # first run: downloads & patches Claude Desktop, then launches
claude-cowork --force    # skip the download confirmation prompt
claude-cowork --doctor   # upstream preflight diagnostics
```

## Notes / caveats

- First launch downloads Anthropic's proprietary Claude Desktop DMG (requires a Claude Pro+ account). Nothing proprietary is committed here or baked into the image.
- Upstream's `/sessions` root symlink still needs `sudo` once per their README.
- `npm install -g electron` pulls a prebuilt binary (~200 MB) into the image at build time.
- `bubblewrap` is likely already present in Bluefin-DX; included for safety (deduped by dnf).

https://claude.ai/code/session_01FcLoHWNyLR1Ni67ynXssEP

---
_Generated by [Claude Code](https://claude.ai/code/session_01FcLoHWNyLR1Ni67ynXssEP)_