### PR TITLE
Harden build pipeline and Waydroid helpers

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,12 +1,12 @@
 name: bluebuild
 on:
   schedule:
-    - cron: "00 17 * * *" # build at 17:00 UTC every day 
-                          # (20 minutes after last ublue images start building)
+    - cron: "00 17 * * *" # build at 17:00 UTC every day
+                           # (20 minutes after last ublue images start building)
   push:
     paths-ignore: # don't rebuild if only documentation has changed
       - "**.md"
-      
+
   pull_request:
   workflow_dispatch: # allow manually triggering builds
 
@@ -27,17 +27,17 @@ jobs:
       fail-fast: false # stop GH from cancelling all matrix builds if one fails
       matrix:
         recipe:
-          # !! Add your recipes here 
+          # !! Add your recipes here
           - recipe.yml
     steps:
-       # the build is fully handled by the reusable github action
+      # Pin actions to immutable commit SHAs because this workflow can publish
+      # packages, mint OIDC tokens, and access the image-signing secret.
       - name: Build Custom Image
-        uses: blue-build/github-action@v1.12
+        uses: blue-build/github-action@836161eb076426a451e6a0054f722b1153b8b3ad # v1.12
         with:
           recipe: ${{ matrix.recipe }}
           cosign_private_key: ${{ secrets.SIGNING_SECRET }}
           registry_token: ${{ github.token }}
           pr_event_number: ${{ github.event.number }}
           maximize_build_space: true
-          # Add these cleanup options:
           rechunk: true

--- a/config/files/usr/bin/claude-cowork
+++ b/config/files/usr/bin/claude-cowork
@@ -27,17 +27,16 @@ fi
 
 if [[ "${1:-}" == "--reinstall" ]]; then
   shift
-  rm -rf "$DEST"
+  rm -rf -- "$DEST"
 fi
 
-# Mirror the read-only source into a writable per-user copy. Preserve the
-# user's extracted app and patches (linux-app-extracted/) across image updates.
+# Mirror the image's reviewed source into the writable per-user copy while
+# preserving the extracted proprietary app. --delete prevents removed or
+# renamed upstream files from lingering indefinitely across image updates.
 mkdir -p "$DEST"
-if command -v rsync >/dev/null 2>&1; then
-  rsync -a --exclude 'linux-app-extracted' "$SRC"/ "$DEST"/
-else
-  cp -rn "$SRC"/. "$DEST"/ 2>/dev/null || cp -r "$SRC"/. "$DEST"/
-fi
+rsync -a --delete \
+  --exclude='linux-app-extracted/' \
+  "$SRC/" "$DEST/"
 
 cd "$DEST"
 

--- a/config/justfiles/waydroid.just
+++ b/config/justfiles/waydroid.just
@@ -11,6 +11,8 @@ alias configure-waydroid := setup-waydroid
 # Set up Waydroid to run Android apps (init / configure / gpu / reset)
 setup-waydroid ACTION="":
     #!/usr/bin/bash
+    set -euo pipefail
+
     OPTION={{ ACTION }}
     if [ "$OPTION" == "help" ]; then
       echo "Usage: ujust setup-waydroid <option>"
@@ -25,22 +27,44 @@ setup-waydroid ACTION="":
       echo "Docs: https://docs.bazzite.gg/Installing_and_Managing_Software/Waydroid_Setup_Guide/"
       OPTION=$(gum choose "Initialize Waydroid" "Configure Waydroid" "Select GPU for Waydroid" "Reset Waydroid (also removes waydroid-related files from user folder)")
     fi
+
     if [[ "${OPTION,,}" =~ ^init ]]; then
       sudo systemctl enable --now waydroid-container
       sudo waydroid init -c 'https://ota.waydro.id/system' -v 'https://ota.waydro.id/vendor'
       echo "Waydroid has been initialized. Launch Waydroid once before running Configure Waydroid."
     elif [[ "${OPTION,,}" =~ ^configure ]]; then
-      git clone https://github.com/ublue-os/waydroid_script.git --depth 1 /tmp/waydroid_script
-      python -m venv /tmp/waydroid_script/venv
-      source /tmp/waydroid_script/venv/bin/activate
-      sudo pip install -r /tmp/waydroid_script/requirements.txt
-      sudo /tmp/waydroid_script/main.py
-      deactivate
-      sudo rm -rf /tmp/waydroid_script
+      # Pin the helper to a reviewed commit. Do not execute the mutable default
+      # branch as root.
+      WAYDROID_SCRIPT_COMMIT=66e5d06bcb92de5d4654bef4d5c7a7c79ee4c9b3
+      WORKDIR=$(mktemp -d -t myos-waydroid.XXXXXXXX)
+      trap 'rm -rf "$WORKDIR"' EXIT
+
+      git init -q "$WORKDIR/repo"
+      git -C "$WORKDIR/repo" remote add origin https://github.com/ublue-os/waydroid_script.git
+      git -C "$WORKDIR/repo" fetch -q --depth=1 origin "$WAYDROID_SCRIPT_COMMIT"
+      git -C "$WORKDIR/repo" checkout -q --detach FETCH_HEAD
+
+      python3 -m venv "$WORKDIR/venv"
+      "$WORKDIR/venv/bin/python" -m pip install --disable-pip-version-check \
+        -r "$WORKDIR/repo/requirements.txt"
+
+      # Use the venv interpreter explicitly across sudo. Activating a venv and
+      # then running `sudo pip` or a shebang script would bypass it.
+      sudo "$WORKDIR/venv/bin/python" "$WORKDIR/repo/main.py"
     elif [[ "${OPTION,,}" =~ gpu ]]; then
       sudo /usr/bin/waydroid-choose-gpu
     elif [[ "${OPTION,,}" =~ ^reset ]]; then
       echo "Resetting Waydroid"
-      bash -c 'sudo rm -rf /var/lib/waydroid /home/.waydroid ~/waydroid ~/.share/waydroid ~/.local/share/applications/*aydroid* ~/.local/share/waydroid'
+      sudo systemctl disable --now waydroid-container.service 2>/dev/null || true
+      sudo rm -rf /var/lib/waydroid
+      rm -rf \
+        "$HOME/.waydroid" \
+        "$HOME/waydroid" \
+        "$HOME/.local/share/waydroid"
+      find "$HOME/.local/share/applications" -maxdepth 1 -type f -iname '*aydroid*' \
+        -delete 2>/dev/null || true
       echo "Waydroid has been reset"
+    else
+      echo "Unknown Waydroid action: $OPTION" >&2
+      exit 2
     fi


### PR DESCRIPTION
## Summary

- pin `blue-build/github-action` to the immutable commit behind v1.12
- pin `ublue-os/waydroid_script` to a reviewed commit before privileged execution
- use the Waydroid virtual environment explicitly across `sudo`
- correct Waydroid reset paths and add strict error handling
- make the Claude Cowork source mirror deterministic with `rsync --delete` while preserving the extracted app

## Why

The previous Waydroid configure path cloned and executed the mutable upstream default branch as root, and `sudo pip` bypassed the activated virtual environment. The workflow also used a mutable action tag despite package, OIDC, and signing-secret access.

## Notes

The Windscribe RPM remains version-pinned but is not checksum-verified in this PR because I could not independently obtain and validate the exact release asset digest. No checksum was invented.
